### PR TITLE
Fix Missing settings path after initial installation

### DIFF
--- a/Flow.Launcher.Plugin.WireGuard/Main.cs
+++ b/Flow.Launcher.Plugin.WireGuard/Main.cs
@@ -76,7 +76,7 @@ namespace Flow.Launcher.Plugin.WireGuard
                 settings = new Settings
                 {
                     SettingsFileLocation = settingsFileLocation,
-                    WireGuardConfigPath = "C:\Program Files\WireGuard\Data\Configurations"
+                    WireGuardConfigPath = @"C:\Program Files\WireGuard\Data\Configurations"
                 };
 
                 settings.Save();

--- a/Flow.Launcher.Plugin.WireGuard/Main.cs
+++ b/Flow.Launcher.Plugin.WireGuard/Main.cs
@@ -75,10 +75,13 @@ namespace Flow.Launcher.Plugin.WireGuard
 
                 settings = new Settings
                 {
-                    SettingsFileLocation = settingsFileLocation
+                    SettingsFileLocation = settingsFileLocation,
+                    WireGuardConfigPath = "C:\Program Files\WireGuard\Data\Configurations"
                 };
 
                 settings.Save();
+
+                interfaceService = new WireGuardInterfaceService(settings.WireGuardConfigPath);
             }
             else
             {


### PR DESCRIPTION
This PR closes #1.

During a new installation, the settigns file was initialized incorrectly and is now set to the default value from the documentation.
also the `Main.interfaceService` object was not initialized in this case