### PR TITLE
Fix `Website` key in `plugin.json`

### DIFF
--- a/Flow.Launcher.Plugin.WireGuard/plugin.json
+++ b/Flow.Launcher.Plugin.WireGuard/plugin.json
@@ -6,7 +6,7 @@
   "Author": "flooxo",
   "Version": "1.0.2",
   "Language": "csharp",
-  "Website": "https://github.com/flooxo/Flow.Plugin.WireGuard",
+  "Website": "https://github.com/flooxo/Flow.Lancher.Plugin.WireGuard",
   "ExecuteFileName": "Flow.Launcher.Plugin.WireGuard.dll",
   "IcoPath": "Images\\wireguard.png"
 }


### PR DESCRIPTION
The `Website` key in the `plugin.json` file has the wrong repository name